### PR TITLE
Add per-customer GitHub Actions pipeline with app-only certificate auth

### DIFF
--- a/.github/workflows/sync-customer-holidays.yml
+++ b/.github/workflows/sync-customer-holidays.yml
@@ -1,0 +1,66 @@
+name: Sync Customer Public Holidays
+
+on:
+  workflow_dispatch:
+    inputs:
+      customer:
+        description: "Customer 'name' from customers.json to sync. Leave blank to sync every customer."
+        required: false
+        type: string
+  schedule:
+    # 03:00 UTC on 1 Dec - ahead of next year's holiday schedules
+    - cron: '0 3 1 12 *'
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: set-matrix
+        shell: pwsh
+        run: |
+          $customers = Get-Content customers.json -Raw | ConvertFrom-Json
+          $filter = "${{ inputs.customer }}"
+          if ($filter) {
+            $customers = @($customers | Where-Object { $_.name -eq $filter })
+          }
+          if (-not $customers -or $customers.Count -eq 0) {
+            Write-Error "No matching customers found in customers.json for filter '$filter'"
+            exit 1
+          }
+          $json = $customers | ConvertTo-Json -Compress -AsArray
+          "matrix={`"include`":$json}" >> $env:GITHUB_OUTPUT
+
+  sync:
+    needs: discover
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+    # Scoping the job to an Environment named after the customer means only that
+    # customer's secrets/variables are exposed to this run - other customers'
+    # credentials are never visible here.
+    environment: ${{ matrix.name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install MicrosoftTeams module
+        shell: pwsh
+        run: Install-Module MicrosoftTeams -Force -Scope CurrentUser -AllowClobber
+
+      - name: Sync holidays for ${{ matrix.displayName }}
+        shell: pwsh
+        env:
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_CERTIFICATE_BASE64: ${{ secrets.AZURE_CERTIFICATE_BASE64 }}
+          AZURE_CERTIFICATE_PASSWORD: ${{ secrets.AZURE_CERTIFICATE_PASSWORD }}
+        run: |
+          ./Sync-CustomerHolidays.ps1 `
+            -CustomerName "${{ matrix.name }}" `
+            -ScheduleName "${{ matrix.scheduleName }}" `
+            -CountryCode "${{ matrix.countryCode }}" `
+            -Region "${{ matrix.region }}"

--- a/README.md
+++ b/README.md
@@ -159,6 +159,44 @@ Start               End
 ```
 
 
+## Multi-Customer Automation (GitHub Actions)
+
+For running this against many customer tenants unattended, `.github/workflows/sync-customer-holidays.yml` authenticates to each customer's own Entra ID tenant using an app-only certificate, and keeps every customer's credentials isolated in their own **GitHub Environment**.
+
+### How it works
+
+- `customers.json` is a routing manifest, one entry per customer. Nothing in it is secret:
+  ```json
+  {
+    "name": "contoso",
+    "displayName": "Contoso Ltd",
+    "scheduleName": "Contoso UK Holidays",
+    "countryCode": "GB",
+    "region": "ENG"
+  }
+  ```
+- The workflow reads `customers.json` and fans out a matrix job per customer.
+- Each matrix job sets `environment: <customer name>`, so GitHub only exposes that one customer's Environment secrets/variables to that job - other customers' credentials are never visible in the same run.
+- `Sync-CustomerHolidays.ps1` reads the tenant/app identity from environment variables, authenticates with `Connect-MicrosoftTeams` using an app-only certificate (no interactive login), and then calls the existing `New-TeamsPublicHolidays` / `Update-TeamsPublicHolidays` functions from `TeamsPublicHolidays.ps1`.
+
+### Onboarding a new customer
+
+1. **Register an app** in the customer's Entra ID tenant (App registrations > New registration). No redirect URI is needed - this is app-only, certificate-based auth.
+2. **Generate a certificate** (a self-signed one is fine) and upload the public key (`.cer`) to the app registration's *Certificates & secrets*. Keep the private key (`.pfx`) - you'll need it in step 5.
+3. **Grant permissions**: assign the Microsoft Teams/Graph application permissions this app needs, and have the customer's tenant admin grant admin consent. Depending on which cmdlets you rely on, you may also need the tenant admin to run `New-CsApplicationAccessPolicy` / `Grant-CsApplicationAccessPolicy` to scope the app's access to the relevant resource account(s) - check current Microsoft Teams PowerShell app-only auth documentation, as required application permissions can change.
+4. **Create a GitHub Environment** in this repository (Settings > Environments) named *exactly* the same as the `name` field you'll use in `customers.json`, e.g. `contoso`.
+5. **Add to that Environment**:
+   - Secrets: `AZURE_CERTIFICATE_BASE64` (the `.pfx` contents, base64-encoded), `AZURE_CERTIFICATE_PASSWORD` (blank if the `.pfx` has no password)
+   - Variables: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`
+   - Optionally add required reviewers or a deployment branch policy on the Environment to control who can trigger a sync against this customer.
+6. **Add an entry** for the customer to `customers.json` (`name`, `scheduleName`, `countryCode`, `region`).
+7. **Run it**: trigger the workflow manually via `workflow_dispatch` (optionally scoped to just this customer), or let the scheduled run pick it up for every customer in `customers.json`.
+
+To base64-encode a `.pfx` for step 5:
+```powershell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("customer-cert.pfx")) | Set-Clipboard
+```
+
 ## Support or Warranty
 These scripts are built by me, intended for me and used on customers tenants that i've had the privilege of supporting. 
 If you want to use this code, you are free to do so. But please note there is absolutely no warranty or direct support offered as part of this free code. Please don't let that deter you from logging issues you may have experienced.

--- a/Sync-CustomerHolidays.ps1
+++ b/Sync-CustomerHolidays.ps1
@@ -1,0 +1,76 @@
+<#
+.SYNOPSIS
+    CI entry point: authenticates to a single customer's Microsoft 365 tenant using an
+    app-only certificate, then creates or updates that customer's Teams holiday schedule.
+
+.DESCRIPTION
+    Designed to run non-interactively from a GitHub Actions job scoped to a per-customer
+    GitHub Environment (see .github/workflows/sync-customer-holidays.yml). Tenant/app
+    identity is read from environment variables so that each customer's credentials stay
+    isolated to that customer's Environment secrets and variables, and are never shared
+    with any other customer's pipeline run.
+
+.NOTES
+    Required environment variables (populated from the calling job's GitHub Environment):
+        AZURE_TENANT_ID             Customer's Entra ID tenant ID                (Environment variable)
+        AZURE_CLIENT_ID             App registration (application) ID           (Environment variable)
+        AZURE_CERTIFICATE_BASE64    Base64-encoded PFX for the app's cert credential (Environment secret)
+        AZURE_CERTIFICATE_PASSWORD  Password protecting the PFX, blank if none  (Environment secret)
+
+    The app registration must have certificate-based, app-only access granted (and admin
+    consented) in the customer's tenant for the Microsoft Teams cmdlets used here.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$CustomerName,
+
+    [Parameter(Mandatory)]
+    [string]$ScheduleName,
+
+    [string]$CountryCode = "GB",
+    [string]$Region = "",
+    [int]$Year = (Get-Date).Year
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "TeamsPublicHolidays.ps1")
+
+foreach ($required in @('AZURE_TENANT_ID', 'AZURE_CLIENT_ID', 'AZURE_CERTIFICATE_BASE64')) {
+    if (-not (Get-Item "env:$required" -ErrorAction SilentlyContinue)) {
+        throw "Missing required environment variable '$required' for customer '$CustomerName'. Check that the GitHub Environment named '$CustomerName' defines it."
+    }
+}
+
+$tenantId = $env:AZURE_TENANT_ID
+$clientId = $env:AZURE_CLIENT_ID
+$certBytes = [Convert]::FromBase64String($env:AZURE_CERTIFICATE_BASE64)
+$cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+    $certBytes, $env:AZURE_CERTIFICATE_PASSWORD, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
+)
+
+$store = [System.Security.Cryptography.X509Certificates.X509Store]::new("My", "CurrentUser")
+$store.Open("ReadWrite")
+$store.Add($cert)
+$store.Close()
+
+try {
+    Write-Host "Authenticating to customer '$CustomerName' (tenant $tenantId) using app-only certificate auth..."
+    Connect-MicrosoftTeams -TenantId $tenantId -ApplicationId $clientId -CertificateThumbprint $cert.Thumbprint | Out-Null
+
+    $existingSchedule = Get-CsOnlineSchedule | Where-Object { $_.Name -eq $ScheduleName }
+    if ($null -eq $existingSchedule) {
+        Write-Host "Schedule '$ScheduleName' not found for '$CustomerName' - creating it."
+        New-TeamsPublicHolidays -ScheduleName $ScheduleName -CountryCode $CountryCode -Region $Region -Year $Year
+    } else {
+        Write-Host "Schedule '$ScheduleName' found for '$CustomerName' - updating it."
+        Update-TeamsPublicHolidays -ScheduleName $ScheduleName -CountryCode $CountryCode -Region $Region -Year $Year
+    }
+} finally {
+    try { Disconnect-MicrosoftTeams -Confirm:$false | Out-Null } catch {}
+
+    $store.Open("ReadWrite")
+    $store.Remove($cert)
+    $store.Close()
+}

--- a/customers.json
+++ b/customers.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "contoso",
+    "displayName": "Contoso Ltd",
+    "scheduleName": "Contoso UK Holidays",
+    "countryCode": "GB",
+    "region": "ENG"
+  },
+  {
+    "name": "fabrikam",
+    "displayName": "Fabrikam Inc",
+    "scheduleName": "Fabrikam DE Holidays",
+    "countryCode": "DE",
+    "region": "BY"
+  }
+]


### PR DESCRIPTION
## Summary
- Adds `customers.json`, a non-secret routing manifest listing each customer (`name`, `scheduleName`, `countryCode`, `region`), where `name` must match a GitHub Environment name.
- Adds `Sync-CustomerHolidays.ps1`, a non-interactive CI entry point that authenticates app-only to a customer's Entra ID tenant via certificate (`Connect-MicrosoftTeams -TenantId -ApplicationId -CertificateThumbprint`), then creates/updates that customer's schedule using the existing functions in `TeamsPublicHolidays.ps1`.
- Adds `.github/workflows/sync-customer-holidays.yml`, which matrices over `customers.json` and scopes each job to `environment: ${{ matrix.name }}` so only that customer's Environment secrets (`AZURE_CERTIFICATE_BASE64`, `AZURE_CERTIFICATE_PASSWORD`) and variables (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`) are exposed to that run — one customer's credentials are never visible in another's job.
- Documents the full onboarding flow in `README.md` (register app, upload certificate, grant consent, create the GitHub Environment, add secrets/vars, add the `customers.json` entry).

## Test plan
- [ ] YAML and JSON validated locally (no PowerShell available in this session to lint the `.ps1` directly)
- [ ] Onboard a real customer (Entra app registration + certificate + GitHub Environment) and run the workflow via `workflow_dispatch` end-to-end
- [ ] Confirm the scheduled cron trigger fires as expected ahead of the next holiday year


---
_Generated by [Claude Code](https://claude.ai/code/session_018YwApnJLkp9uFwJSoxhGeJ)_