### PR TITLE
Fix annual rollover so scheduled/manual runs prepare next year's schedule

### DIFF
--- a/.github/workflows/sync-customer-holidays.yml
+++ b/.github/workflows/sync-customer-holidays.yml
@@ -7,8 +7,12 @@ on:
         description: "Customer 'name' from customers.json to sync. Leave blank to sync every customer."
         required: false
         type: string
+      year:
+        description: "Calendar year to process, e.g. 2027. Leave blank to default to next calendar year."
+        required: false
+        type: string
   schedule:
-    # 03:00 UTC on 1 Dec - ahead of next year's holiday schedules
+    # 03:00 UTC on 1 Dec - prepares next year's holiday schedules ahead of the new year
     - cron: '0 3 1 12 *'
 
 jobs:
@@ -16,8 +20,35 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      year: ${{ steps.resolve-year.outputs.year }}
     steps:
       - uses: actions/checkout@v4
+
+      - id: resolve-year
+        shell: pwsh
+        run: |
+          $inputYear = "${{ inputs.year }}"
+          $isScheduled = "${{ github.event_name }}" -eq "schedule"
+
+          if ($isScheduled -or [string]::IsNullOrWhiteSpace($inputYear)) {
+            # Scheduled runs (1 Dec) and blank manual input both default to next calendar year,
+            # since a run on 1 Dec 2026 should be preparing the 2027 schedule, not updating 2026.
+            $resolvedYear = (Get-Date).Year + 1
+          } else {
+            if ($inputYear -notmatch '^\d{4}$') {
+              Write-Error "The 'year' input must be a 4-digit integer, got '$inputYear'"
+              exit 1
+            }
+            $resolvedYear = [int]$inputYear
+            if ($resolvedYear -lt 2000 -or $resolvedYear -gt 2100) {
+              Write-Error "The 'year' input must be between 2000 and 2100, got '$resolvedYear'"
+              exit 1
+            }
+          }
+
+          Write-Host "Resolved year for this run: $resolvedYear (trigger: ${{ github.event_name }})"
+          "### Public Holiday Sync`nProcessing year: **$resolvedYear** (trigger: ``${{ github.event_name }}``)" >> $env:GITHUB_STEP_SUMMARY
+          "year=$resolvedYear" >> $env:GITHUB_OUTPUT
 
       - id: set-matrix
         shell: pwsh
@@ -59,8 +90,13 @@ jobs:
           AZURE_CERTIFICATE_BASE64: ${{ secrets.AZURE_CERTIFICATE_BASE64 }}
           AZURE_CERTIFICATE_PASSWORD: ${{ secrets.AZURE_CERTIFICATE_PASSWORD }}
         run: |
+          $year = ${{ needs.discover.outputs.year }}
+          Write-Host "Processing year $year for customer '${{ matrix.name }}'"
+          "- ${{ matrix.displayName }} (``${{ matrix.name }}``): year $year" >> $env:GITHUB_STEP_SUMMARY
+
           ./Sync-CustomerHolidays.ps1 `
             -CustomerName "${{ matrix.name }}" `
             -ScheduleName "${{ matrix.scheduleName }}" `
             -CountryCode "${{ matrix.countryCode }}" `
-            -Region "${{ matrix.region }}"
+            -Region "${{ matrix.region }}" `
+            -Year $year

--- a/README.md
+++ b/README.md
@@ -197,6 +197,16 @@ To base64-encode a `.pfx` for step 5:
 [Convert]::ToBase64String([IO.File]::ReadAllBytes("customer-cert.pfx")) | Set-Clipboard
 ```
 
+### Which year gets processed?
+
+The workflow runs on a schedule every **1 December**, and always prepares the *following* calendar year's holidays - a run on 1 December 2026 processes **2027**, not 2026, so the new schedule is in place well before the year it applies to.
+
+- **Scheduled run**: always uses next calendar year (current year + 1). This is not configurable.
+- **Manual run (`workflow_dispatch`) with no `year` input**: also defaults to next calendar year, matching the scheduled behaviour.
+- **Manual run with a `year` input**: processes exactly the year you specify (e.g. `year=2028` processes 2028), which is useful for backfilling a schedule or re-running a year that needs correcting.
+
+To run it manually for a specific year: go to Actions > Sync Customer Public Holidays > Run workflow, optionally set `customer` to a single customer's `name`, and set `year` to a 4-digit year between 2000 and 2100. The resolved year is validated up front (the run fails fast with a clear error if it's out of range or not 4 digits) and is echoed in the job log and the workflow run's job summary.
+
 ## Support or Warranty
 These scripts are built by me, intended for me and used on customers tenants that i've had the privilege of supporting. 
 If you want to use this code, you are free to do so. But please note there is absolutely no warranty or direct support offered as part of this free code. Please don't let that deter you from logging issues you may have experienced.

--- a/Sync-CustomerHolidays.ps1
+++ b/Sync-CustomerHolidays.ps1
@@ -59,6 +59,8 @@ try {
     Write-Host "Authenticating to customer '$CustomerName' (tenant $tenantId) using app-only certificate auth..."
     Connect-MicrosoftTeams -TenantId $tenantId -ApplicationId $clientId -CertificateThumbprint $cert.Thumbprint | Out-Null
 
+    Write-Host "Processing schedule '$ScheduleName' for customer '$CustomerName' - year $Year (country $CountryCode, region $Region)"
+
     $existingSchedule = Get-CsOnlineSchedule | Where-Object { $_.Name -eq $ScheduleName }
     if ($null -eq $existingSchedule) {
         Write-Host "Schedule '$ScheduleName' not found for '$CustomerName' - creating it."


### PR DESCRIPTION
## Summary
- `.github/workflows/sync-customer-holidays.yml`: adds a `resolve-year` step in the `discover` job that computes the year to process. Scheduled runs and manual runs with a blank `year` input both resolve to `(Get-Date).Year + 1`, so a run on 1 December 2026 processes 2027 instead of 2026.
- Adds an optional `year` input to `workflow_dispatch`, validated as a 4-digit integer between 2000 and 2100 (the job fails fast with a clear error otherwise).
- The resolved year is passed explicitly to `Sync-CustomerHolidays.ps1` via `-Year`, and is written to both the workflow log (`Write-Host`) and the GitHub Actions job summary (`$GITHUB_STEP_SUMMARY`), including per-customer lines in the `sync` job.
- `Sync-CustomerHolidays.ps1`: added a log line stating the schedule/customer/year being processed, useful when the script is run directly outside the pipeline.
- `README.md`: new "Which year gets processed?" section explaining the 1 December rollover, the next-year default, and how to run the workflow manually for a specific year.
- The per-customer matrix and GitHub Environment isolation model (`environment: ${{ matrix.name }}`) are unchanged.

## Resolved year logic
- Scheduled trigger (`github.event_name == 'schedule'`) → always `(Get-Date).Year + 1`.
- `workflow_dispatch` with blank/whitespace `year` input → also `(Get-Date).Year + 1`.
- `workflow_dispatch` with a `year` input → used as-is, after validation.

## Validation added
- `year` input must match `^\d{4}$` (exactly 4 digits) or the run fails with `Write-Error` + `exit 1`.
- Parsed value must be between 2000 and 2100 inclusive, or the run fails the same way.
- Validation happens once in the `discover` job, before any customer's Environment/credentials are touched.

## Remaining risks / assumptions
- `${{ inputs.year }}` and `${{ inputs.customer }}` are interpolated directly into the `pwsh` script text before execution (pre-existing pattern from the original workflow). `workflow_dispatch` requires repo write access to trigger, so this isn't exploitable by outside actors, but it's not hardened against script/quote injection the way passing inputs via `env:` would be - worth tightening in a follow-up if this repo ever opens `workflow_dispatch` more broadly.
- Assumes GitHub-hosted `ubuntu-latest` runners keep clocks in UTC, so "current year" at 03:00 UTC on 1 Dec matches the intended rollover date; a differently-configured self-hosted runner could shift this by a day at most.
- Not able to execute the workflow live in this environment (no `pwsh`/GitHub Actions runner available here) - YAML/JSON were validated for syntax only. Recommend a manual `workflow_dispatch` test run (with and without a `year` input) before relying on the next scheduled 1 Dec run.


---
_Generated by [Claude Code](https://claude.ai/code/session_018YwApnJLkp9uFwJSoxhGeJ)_