### PR TITLE
Add GitHub Pages documentation site under /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This script fetches public holiday data from an external API and updates the holiday schedule in Microsoft Teams for Auto-Attendants to consume.
 
+📖 **Full documentation, background, use cases, examples and FAQ:** see the [`/docs`](docs/index.md) folder, published via GitHub Pages once enabled (Settings > Pages > Source: Deploy from a branch > main / docs).
+
 ##
 
 - Author: Simon Jackson (@sjackson0109)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,13 @@
+title: Teams Public Holidays
+description: >-
+  Manage Microsoft Teams Auto-Attendant / Call Queue holiday schedules from
+  public holiday data - for a single tenant, or for many customer tenants
+  unattended via GitHub Actions.
+theme: jekyll-theme-cayman
+markdown: kramdown
+plugins:
+  - jekyll-relative-links
+relative_links:
+  enabled: true
+  collections: false
+show_downloads: false

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,85 @@
+---
+title: Automation & Pipelines
+---
+
+[Home](index.md) · [Background](background.md) · [Use Cases](use-cases.md) · [Automation & Pipelines](automation.md) · [Examples](examples.md) · [FAQ](faq.md)
+
+# Automation & Pipelines
+
+This page is a deep dive into `.github/workflows/sync-customer-holidays.yml` - the GitHub Actions pipeline that runs the toolkit unattended against many customer tenants. For the onboarding checklist, see the [README](https://github.com/sjackson0109/TeamsPublicHolidays#multi-customer-automation-github-actions); this page covers the *why* and the mechanics in more depth.
+
+## The problem it solves
+
+Running `Connect-MicrosoftTeams` interactively works fine for one tenant, but doesn't scale to supporting many customer tenants, and doesn't isolate credentials from each other if you try to script it naively (one shared secret, or secrets sitting in the same scope, means a bug or a compromise in one customer's run can expose another's). The pipeline is built around two ideas:
+
+1. **App-only authentication per customer**, so no interactive sign-in and no shared identity is used across tenants.
+2. **Per-customer GitHub Environments**, so GitHub itself enforces that a job only ever sees the secrets belonging to the customer it's processing.
+
+## Architecture
+
+```
+customers.json  ──►  discover job  ──►  matrix (one entry per customer)
+                        │
+                        ├─ resolve-year: works out which calendar year to process
+                        └─ set-matrix: filters customers.json (optionally to one customer)
+                                │
+                                ▼
+                       sync job (one per matrix entry)
+                       environment: <customer name>   ◄── scopes secrets/vars to this customer only
+                                │
+                                ▼
+                 Sync-CustomerHolidays.ps1
+                   1. import cert from AZURE_CERTIFICATE_BASE64 (Environment secret)
+                   2. Connect-MicrosoftTeams -TenantId -ApplicationId -CertificateThumbprint
+                   3. New-/Update-TeamsPublicHolidays for that customer's schedule
+                   4. disconnect, remove cert from the runner's cert store
+```
+
+The `discover` job runs once and produces two outputs consumed by every customer's `sync` job: the resolved `year`, and a JSON matrix built from `customers.json` (optionally filtered to a single customer via the `customer` input). The `sync` job then fans out, one job per customer, with `fail-fast: false` so one customer's failure doesn't stop the others from running.
+
+## Why certificate-based app-only auth
+
+The pipeline authenticates using a certificate credential on an Entra ID app registration, rather than a client secret or an interactive login:
+
+- **No interactive session** - a service can't click through an MFA prompt, so app-only auth is required for unattended automation.
+- **No shared identity across customers** - each customer has their own app registration, in their own tenant, so there is no single credential whose compromise affects every customer at once.
+- **Stronger than a client secret** - a certificate's private key never needs to be transmitted to Microsoft during authentication (unlike a client secret, which is sent on every token request), and certificates are generally easier to constrain and audit.
+
+`Sync-CustomerHolidays.ps1` imports the certificate from a base64-encoded secret into the runner's ephemeral certificate store for the duration of the job, authenticates, and removes it again in a `finally` block - the certificate never persists beyond a single job run.
+
+## Why per-customer GitHub Environments
+
+A [GitHub Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) is a named scope that a job can opt into via `environment: <name>`. Secrets and variables defined on an Environment are only exposed to jobs that declare that Environment - jobs for a different Environment (or no Environment) cannot see them.
+
+By naming each customer's Environment after that customer's `name` in `customers.json`, and setting `environment: ${{ matrix.name }}` on the `sync` job, GitHub enforces the isolation structurally: there's no code path in the workflow that could accidentally read `contoso`'s certificate while processing `fabrikam`. This also means:
+
+- Environments can carry their own protection rules (required reviewers, deployment branch restrictions) if you want a human gate before a sync runs against a particular customer.
+- Revoking a customer's access is a matter of deleting their Environment and app registration - it doesn't require touching any other customer's configuration.
+
+## What lives where
+
+| Data | Location | Secret? |
+|---|---|---|
+| Customer routing info (`name`, `scheduleName`, `countryCode`, `region`) | `customers.json` in the repo | No |
+| Tenant ID, Application (client) ID | The customer's GitHub Environment, as **variables** (`vars.AZURE_TENANT_ID`, `vars.AZURE_CLIENT_ID`) | No, but scoped |
+| Certificate (base64 PFX) and its password | The customer's GitHub Environment, as **secrets** (`secrets.AZURE_CERTIFICATE_BASE64`, `secrets.AZURE_CERTIFICATE_PASSWORD`) | Yes |
+
+`customers.json` is intentionally not secret - it's just a routing table. Nothing in it would help an attacker without also having access to the matching customer's GitHub Environment secrets.
+
+## Triggers and year resolution
+
+The workflow has two triggers:
+
+- **`schedule`**: `0 3 1 12 *` - 03:00 UTC on 1 December every year.
+- **`workflow_dispatch`**: manual, with two optional inputs - `customer` (limit the run to one customer) and `year` (process a specific year).
+
+A dedicated `resolve-year` step works out which year to process, and validates it before any customer's credentials are touched:
+
+- On a scheduled run, or a manual run with `year` left blank, the resolved year is always **next calendar year** - a run on 1 December 2026 prepares **2027**. This is deliberate: the point of running in early December is to have the following year's schedule ready well in advance, not to patch the current year.
+- On a manual run with `year` supplied, it's validated as a 4-digit integer between 2000 and 2100, and used exactly as given - useful for backfilling or correcting a specific year.
+
+The resolved year is written to the workflow log (`Write-Host`) and to the GitHub Actions job summary, both once for the whole run and again per customer, so it's easy to confirm at a glance which year a given run actually processed.
+
+## Onboarding checklist
+
+The step-by-step onboarding process (registering an app, uploading a certificate, granting consent, creating the GitHub Environment, adding secrets/variables, and adding a `customers.json` entry) is documented in the [README's "Multi-Customer Automation" section](https://github.com/sjackson0109/TeamsPublicHolidays#multi-customer-automation-github-actions) to keep it next to the code it describes.

--- a/docs/background.md
+++ b/docs/background.md
@@ -1,0 +1,40 @@
+---
+title: Background
+---
+
+[Home](index.md) · [Background](background.md) · [Use Cases](use-cases.md) · [Automation & Pipelines](automation.md) · [Examples](examples.md) · [FAQ](faq.md)
+
+# Background
+
+## The problem
+
+Microsoft Teams Auto-Attendants and Call Queues support a "holiday schedule" (`CsOnlineSchedule`) - a set of date ranges that trigger out-of-hours call routing. It's a genuinely useful feature: a receptionist doesn't need to remember to flip a switch on Christmas Day, the schedule just knows.
+
+The catch is that Teams doesn't populate that schedule for you. Someone has to know every relevant public holiday, in the right region, for the right year, and type each one in - through the admin center or through PowerShell, one `New-CsOnlineDateTimeRange` at a time. For a single UK organisation that's a dozen or so dates a year. For someone supporting dozens of customer tenants across multiple countries, each with their own regional variations, it becomes a recurring, error-prone chore that's easy to deprioritise until a customer's auto-attendant fails to switch to the holiday greeting.
+
+## The origin
+
+This project started in December 2023 as a single function to keep one UK schedule current, using a hint from [Bjoren Dassow (@dassbj01)](https://github.com/dassbj01) about the [date.nager.at](https://date.nager.at) public holiday API - a free, actively maintained service covering dozens of countries with structured, machine-readable holiday data (including which holidays are nationwide vs. regional).
+
+From there it grew in response to real support work:
+
+- **Germany support** was added within days, because German public holidays vary significantly by federal state (`Land`) - a pattern that repeats in many countries (the UK's home nations, Spain's autonomous communities, and so on).
+- **Regional filtering** was added by [Mitchell Bakker (@mitchelljb)](https://github.com/mitchelljb), turning a country-wide holiday list into one correctly scoped to a specific region/county, and cleaning up how that data set is presented.
+- **Pruning** was added once it became clear that schedules left to accumulate past dates get harder to read and slower for the Teams service to evaluate - removing stale ranges at source keeps the data set lean.
+- **Multi-customer automation** was added most recently, turning what had been a manual, per-tenant PowerShell exercise (documented candidly in the README as being "used on customer tenants that I've had the privilege of supporting") into a GitHub Actions pipeline that can authenticate to and update *any number* of customer tenants unattended, each isolated from the others. See [Automation & Pipelines](automation.md) for how that works.
+
+The full list of changes is in the [Changelog](https://github.com/sjackson0109/TeamsPublicHolidays/blob/main/Changelog.md).
+
+## Design principles
+
+A few decisions run through the whole project:
+
+- **One schedule, many consumers.** A single `CsOnlineSchedule` can be attached to any number of auto-attendants or call queues. The tooling updates one shared table of dates rather than duplicating holiday data per call flow.
+- **Data comes from an external source of truth, not a hand-maintained list.** Holiday dates are fetched live from `date.nager.at` rather than hardcoded, so the same tool works for any supported country without code changes - only a country/region code needs to change.
+- **Idempotent by default.** Running the update functions again doesn't duplicate dates already present, and past dates are pruned automatically, so the tool is safe to run repeatedly (interactively, or on an annual schedule).
+- **Small, composable functions.** `Get-PublicHolidays`, `New-TeamsPublicHolidays`, `Update-TeamsPublicHolidays`, and `Prune-TeamsPublicHolidays` each do one job and can be used independently - which is also what makes them straightforward to wrap in a non-interactive CI script.
+- **Credentials never get mixed between customers.** Once the tool needed to run against many customer tenants unattended, the automation was built so that each customer's tenant ID, app ID, and certificate live only in that customer's own GitHub Environment - a pipeline run for one customer structurally cannot see another customer's secrets.
+
+## Who maintains it
+
+This is a small, personally-maintained project by [Simon Jackson (@sjackson0109)](https://github.com/sjackson0109), built out of real support work and shared publicly under an open licence. There's no commercial backing or SLA - see the [FAQ](faq.md) and the project's README for the support expectations.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,147 @@
+---
+title: Examples
+---
+
+[Home](index.md) · [Background](background.md) · [Use Cases](use-cases.md) · [Automation & Pipelines](automation.md) · [Examples](examples.md) · [FAQ](faq.md)
+
+# Examples
+
+All examples assume you've already connected interactively (`Connect-MicrosoftTeams`) and imported the module (`Import-Module .\TeamsPublicHolidays.ps1`) as described on the [Home](index.md) page. For the unattended, multi-customer version of these same operations, see [Automation & Pipelines](automation.md).
+
+## Creating a new schedule
+
+Create a new schedule called `UK National Holidays`, filtered to England only, for the current year:
+
+```powershell
+New-TeamsPublicHolidays -ScheduleName 'UK National Holidays' -CountryCode 'GB' -Region 'ENG'
+```
+
+| Command | Result |
+|---|---|
+| ![UK 2024 Command](https://raw.githubusercontent.com/sjackson0109/TeamsPublicHolidays/main/Examples/UK_2024.png) | ![UK 2024 Result](https://raw.githubusercontent.com/sjackson0109/TeamsPublicHolidays/main/Examples/UK_2024_Result.png) |
+
+## Updating an existing schedule for a specific year
+
+```powershell
+Update-TeamsPublicHolidays -ScheduleName 'DE National Holidays' -CountryCode 'DE' -Year '2024'
+```
+
+| Command | Result |
+|---|---|
+| ![DE 2024 Command](https://raw.githubusercontent.com/sjackson0109/TeamsPublicHolidays/main/Examples/DE_2024.png) | ![DE 2024 Result](https://raw.githubusercontent.com/sjackson0109/TeamsPublicHolidays/main/Examples/DE_2024_Result.png) |
+
+## Filtering to a region
+
+Germany's public holidays vary by federal state. This creates/updates a schedule for Berlin only:
+
+```powershell
+Update-TeamsPublicHolidays -ScheduleName 'Berlin Holidays' -CountryCode 'DE' -Region 'BE'
+```
+
+And for Poland, for 2025:
+
+```powershell
+Update-TeamsPublicHolidays -ScheduleName 'Polish National Holidays' -CountryCode 'PL' -Year '2025'
+```
+
+## Previewing what a query will return
+
+Before wiring a schedule up, it's worth checking what `Get-PublicHolidays` actually returns for a given country and region - this is the same data `New-`/`Update-TeamsPublicHolidays` will write into the schedule.
+
+```powershell
+Get-PublicHolidays | ft
+
+Fetching holidays from URL: https://date.nager.at/api/v3/PublicHolidays/2024/GB
+ - dates retrieved: 15
+ - dates including global indicator: 15
+
+Date       Name                   Global CountryCode Counties
+----       ----                   ------ ----------- --------
+2024-01-01 New Year`s Day          False GB          ENG, NIR, SCT, WLS
+2024-01-02 2 January               False GB          SCT
+2024-03-18 Saint Patrick`s Day     False GB          NIR
+2024-03-29 Good Friday              True GB
+2024-04-01 Easter Monday           False GB          ENG, NIR, WLS
+2024-05-06 Early May Bank Holiday   True GB
+2024-05-27 Spring Bank Holiday      True GB
+2024-07-12 Battle of the Boyne     False GB          NIR
+2024-08-05 Summer Bank Holiday     False GB          SCT
+2024-08-26 Summer Bank Holiday     False GB          ENG, NIR, WLS
+2024-12-02 Saint Andrew`s Day      False GB          SCT
+2024-12-25 Christmas Day            True GB
+2024-12-26 St. Stephen`s Day        True GB
+```
+
+Now scope it to England only, and compare the count:
+
+```powershell
+Get-PublicHolidays -CountryCode GB -Region ENG | ft
+
+Fetching holidays from URL: https://date.nager.at/api/v3/PublicHolidays/2024/GB
+ - dates retrieved: 15
+ - dates including global indicator: 15
+ - dates including region filtering: 8    <==== IS THIS WHAT YOU EXPECT?
+
+Date       Name                   Global CountryCode Counties
+----       ----                   ------ ----------- --------
+2024-01-01 New Year`s Day          False GB          ENG, WLS
+2024-03-29 Good Friday              True GB
+2024-04-01 Easter Monday           False GB          ENG, NIR, WLS
+2024-05-06 Early May Bank Holiday   True GB
+2024-05-27 Spring Bank Holiday      True GB
+2024-08-26 Summer Bank Holiday     False GB          ENG, NIR, WLS
+2024-12-25 Christmas Day            True GB
+2024-12-26 St. Stephen`s Day        True GB
+```
+
+## Replacing all dates in a schedule
+
+```powershell
+Update-TeamsPublicHolidays -ScheduleName 'English Holidays' -CountryCode 'GB' -Region 'ENG' -Year '2025' -Replace
+```
+
+> **Note:** as of the current release, the `-Replace` code path is a documented placeholder (it logs a message rather than clearing and rewriting the schedule) - see the [FAQ](faq.md) for what to do instead today.
+
+## Pruning past dates
+
+```powershell
+Prune-TeamsPublicHolidays -ScheduleName 'UK National Holidays'
+
+CURRENT DATES:
+
+Start               End
+-----               ---
+18/06/2024 00:00:00 19/06/2024 00:00:00             <======== THIS IS AN OLD RECORD
+25/12/2024 00:00:00 26/12/2024 00:00:00
+26/12/2024 00:00:00 27/12/2024 00:00:00
+
+
+REMAINING DATES AFTER PRUNING:
+
+Start               End
+-----               ---
+25/12/2024 00:00:00 26/12/2024 00:00:00
+26/12/2024 00:00:00 27/12/2024 00:00:00
+```
+
+## Running the multi-customer pipeline for one customer
+
+Given this entry in `customers.json`:
+
+```json
+{
+  "name": "contoso",
+  "displayName": "Contoso Ltd",
+  "scheduleName": "Contoso UK Holidays",
+  "countryCode": "GB",
+  "region": "ENG"
+}
+```
+
+Triggering **Actions > Sync Customer Public Holidays > Run workflow** with `customer: contoso` and `year` left blank will:
+
+1. Resolve the year to next calendar year (e.g. 2027, if run during 2026).
+2. Filter `customers.json` down to just the `contoso` entry.
+3. Run the `sync` job scoped to the `contoso` GitHub Environment, authenticating to Contoso's own tenant and updating `Contoso UK Holidays` for 2027.
+
+Setting `year: 2028` instead would process 2028 for Contoso specifically, regardless of what year it currently is. Leaving `customer` blank runs the same process for every entry in `customers.json`, each in its own isolated job. See [Automation & Pipelines](automation.md) for the full mechanics.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,101 @@
+---
+title: FAQ
+---
+
+[Home](index.md) · [Background](background.md) · [Use Cases](use-cases.md) · [Automation & Pipelines](automation.md) · [Examples](examples.md) · [FAQ](faq.md)
+
+# Frequently Asked Questions
+
+### What does this project actually do?
+
+It fetches public holiday data from [date.nager.at](https://date.nager.at) and writes it into a Microsoft Teams `CsOnlineSchedule`, which any number of Auto-Attendants or Call Queues can reference to trigger out-of-hours call routing on public holidays. See [Background](background.md) and [Use Cases](use-cases.md).
+
+### What is a `CsOnlineSchedule`, exactly?
+
+It's the Teams Voice object that defines a "holiday schedule" or "business hours schedule" - a named set of date/time ranges. Auto-Attendants and Call Queues reference a schedule by name and change their call routing behaviour (e.g. play a holiday greeting) whenever the current time falls inside one of its ranges.
+
+### Do I need Teams Admin rights to use this?
+
+Yes. Interactively, you need whatever role lets you run `Connect-MicrosoftTeams` and manage `CsOnlineSchedule` objects (typically Teams Administrator or a similarly-scoped role). For the automated pipeline, the app registration used for app-only auth needs equivalent application-level permissions granted and admin-consented in the customer's tenant - see [Automation & Pipelines](automation.md).
+
+### What PowerShell version and OS does this need?
+
+The core script (`TeamsPublicHolidays.ps1`) targets PowerShell 3.0 or later with the `MicrosoftTeams` module installed. The `MicrosoftTeams` module itself is REST-based and works cross-platform under PowerShell 7+ (Windows, macOS, Linux), which is also why the GitHub Actions pipeline runs happily on `ubuntu-latest` runners using `pwsh`.
+
+### Where does the holiday data come from, and how accurate is it?
+
+From [date.nager.at](https://date.nager.at), a free, community-maintained public holiday API covering dozens of countries with structured data distinguishing nationwide (`Global`) holidays from region/county-specific ones. It's actively maintained, but like any third-party data source it's worth spot-checking a new country/region the first time you use it (see [Examples](examples.md) for how to preview results with `Get-PublicHolidays` before writing anything to Teams).
+
+### What if my country or region isn't covered by the API?
+
+`Get-PublicHolidays` will return an empty result (and log an error) for a country code the API doesn't recognise. Check the [date.nager.at](https://date.nager.at) documentation for supported countries. There's currently no fallback data source built into this project.
+
+### What's the difference between `New-`, `Update-`, and `Prune-TeamsPublicHolidays`?
+
+- `New-TeamsPublicHolidays` creates a brand-new schedule and populates it with holidays for the given country/region/year.
+- `Update-TeamsPublicHolidays` adds any missing holidays to an *existing* schedule (matched by name) without duplicating ones already present, and prunes past dates while it's at it.
+- `Prune-TeamsPublicHolidays` only removes past-dated ranges from an existing schedule; it doesn't fetch or add anything new.
+
+### Does `-Replace` on `Update-TeamsPublicHolidays` actually replace the schedule?
+
+Not yet - as of the current release, the `-Replace` switch is a documented placeholder in the code; it logs a message rather than clearing and rewriting the schedule's dates. If you need to fully replace a schedule's contents today, delete the existing `CsOnlineSchedule` and recreate it with `New-TeamsPublicHolidays`, or open an issue if you'd like to help implement `-Replace` properly.
+
+### Why are past holidays automatically removed?
+
+Two reasons: date ranges that have already ended serve no purpose in a holiday schedule, and Teams has to evaluate every range in a schedule at call time - keeping the data set lean keeps that evaluation fast and the schedule easy for a human to read. See [Background](background.md#design-principles).
+
+### Can one holiday schedule serve multiple auto-attendants?
+
+Yes, and this is one of the main efficiency wins of the project - see [Use Cases](use-cases.md#2-one-schedule-many-call-flows). Point every auto-attendant/call queue that shares the same holiday calendar at the same schedule name, and update that one schedule.
+
+### How does the multi-customer pipeline work, in short?
+
+A GitHub Actions workflow reads `customers.json`, and for each customer authenticates to that customer's own Entra ID tenant using an app-only certificate, then runs the same `New-`/`Update-TeamsPublicHolidays` logic against that customer's schedule - all inside a job scoped to a GitHub Environment named after the customer, so credentials never cross between customers. Full detail on [Automation & Pipelines](automation.md).
+
+### Why certificate auth instead of a client secret, for the pipeline?
+
+A certificate's private key is never transmitted to Microsoft during authentication, unlike a client secret which is sent on every token request - and certificates are generally easier to scope, rotate, and audit per app registration. See [Automation & Pipelines](automation.md#why-certificate-based-app-only-auth).
+
+### Where are a customer's secrets actually stored?
+
+In that customer's GitHub Environment (Settings > Environments in this repository), as Environment secrets (`AZURE_CERTIFICATE_BASE64`, `AZURE_CERTIFICATE_PASSWORD`) and Environment variables (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`). `customers.json` in the repo itself holds no secrets - only non-sensitive routing information (customer name, schedule name, country/region).
+
+### How is one customer's pipeline run kept from seeing another customer's secrets?
+
+The `sync` job in the workflow sets `environment: ${{ matrix.name }}`, and GitHub Environments only expose their secrets/variables to jobs that declare that specific Environment. There's no shared credential or shared scope a bug could leak across - the isolation is enforced by GitHub itself, not by application logic. See [Automation & Pipelines](automation.md#why-per-customer-github-environments).
+
+### What Microsoft Teams/Graph permissions does the app registration need?
+
+This depends on which cmdlets you rely on and can change as Microsoft evolves app-only support for Teams PowerShell, so check current Microsoft documentation before granting permissions. At minimum you'll need the application permissions required for the `CsOnlineSchedule` cmdlets, admin-consented in the customer's tenant; some environments additionally require `New-CsApplicationAccessPolicy` / `Grant-CsApplicationAccessPolicy` to scope the app's access to specific resource accounts.
+
+### When does the scheduled pipeline run, and which year does it process?
+
+It runs at 03:00 UTC on 1 December every year, and always processes **next** calendar year - a run on 1 December 2026 prepares 2027, not 2026. This is deliberate, so the following year's schedule is in place well in advance. See [Automation & Pipelines](automation.md#triggers-and-year-resolution).
+
+### Can I run the pipeline manually for a specific year?
+
+Yes - trigger it via `workflow_dispatch` and set the `year` input to any 4-digit year between 2000 and 2100. Leaving it blank defaults to next calendar year, matching the scheduled behaviour. An out-of-range or malformed year fails the run immediately with a clear error, before any customer's credentials are touched.
+
+### What happens if I run the workflow for a customer name that isn't in `customers.json`?
+
+The `discover` job's matrix-building step fails fast with an explicit error ("No matching customers found...") before any authentication is attempted, rather than silently doing nothing.
+
+### Is there a cost to running this via GitHub Actions?
+
+Only the normal GitHub Actions compute minutes for your plan/repo visibility (public repositories on GitHub.com currently get free Actions minutes; private repositories draw from your account's included minutes or billed usage). The workflow itself is lightweight - a short-lived job per customer, once a year plus however often you trigger it manually.
+
+### How do I rotate a customer's certificate before it expires?
+
+Generate a new certificate, upload its public key to the same app registration (or a new one), and update that customer's `AZURE_CERTIFICATE_BASE64` / `AZURE_CERTIFICATE_PASSWORD` Environment secrets with the new `.pfx`. No code or workflow changes are needed - the pipeline just reads whatever is currently in the Environment.
+
+### How do I decommission a customer?
+
+Remove their entry from `customers.json` and delete their GitHub Environment (and, in their tenant, the app registration and certificate) once you're done. There's nothing else in the codebase that references a specific customer.
+
+### Is this project officially supported by Microsoft, or by the maintainer as a commercial product?
+
+No to both. It's an independent, openly-licensed project built by [Simon Jackson (@sjackson0109)](https://github.com/sjackson0109) out of real Teams Voice support work, provided as-is with no warranty or guaranteed support - see the project [README](https://github.com/sjackson0109/TeamsPublicHolidays#support-or-warranty).
+
+### I found a bug, or want to suggest a feature - what do I do?
+
+Open an issue (or a discussion, for a more open-ended idea) on the [GitHub repository](https://github.com/sjackson0109/TeamsPublicHolidays/issues). Feedback and bug reports are genuinely useful even though there's no formal support commitment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,60 @@
+---
+title: Home
+---
+
+[Home](index.md) · [Background](background.md) · [Use Cases](use-cases.md) · [Automation & Pipelines](automation.md) · [Examples](examples.md) · [FAQ](faq.md)
+
+# Teams Public Holidays
+
+**Teams Public Holidays** keeps Microsoft Teams Auto-Attendant and Call Queue holiday schedules up to date, automatically, using public holiday data pulled from a free REST API.
+
+Instead of manually typing dates into a `CsOnlineSchedule` every year - and forgetting to do it, or getting a region wrong - this project fetches accurate, region-aware public holiday dates and writes them straight into the schedule your call flows already use.
+
+It works two ways:
+
+- **As a PowerShell toolkit** you run yourself, interactively, against one Microsoft 365 tenant.
+- **As a GitHub Actions pipeline** that runs unattended against *many* customer tenants, each authenticated independently and each with its own isolated credentials.
+
+## Why this exists
+
+Anyone who has supported Teams Voice for more than one organisation knows the pattern: every December, someone has to remember to add next year's bank holidays to every auto-attendant's schedule, get the regional variations right, and prune the old dates so the schedule doesn't bloat. It's fiddly, easy to get wrong, and easy to forget. This project turns that into a single command - or a fully automated annual pipeline run. See [Background](background.md) for the full story.
+
+## What it does
+
+- **Fetches holidays dynamically** from [date.nager.at](https://date.nager.at), filtered by country and, where relevant, by region/county (e.g. Bavaria-only holidays in Germany, or Scotland-only holidays in the UK).
+- **Creates or updates** a Teams `CsOnlineSchedule` with those dates, so every auto-attendant or call queue pointed at that schedule picks up the change instantly - update one schedule, and every call flow attached to it benefits.
+- **Prunes past dates automatically**, so schedules never carry forward holidays that have already happened.
+- **Scales to many customers** via a GitHub Actions pipeline that authenticates to each customer's own Entra ID tenant using an app-only certificate, with each customer's secrets isolated in their own GitHub Environment. See [Automation & Pipelines](automation.md).
+
+## Quick start
+
+```powershell
+Install-Module MicrosoftTeams
+Import-Module MicrosoftTeams
+Connect-MicrosoftTeams
+
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope Process
+Import-Module .\TeamsPublicHolidays.ps1
+
+New-TeamsPublicHolidays -ScheduleName 'UK National Holidays' -CountryCode 'GB' -Region 'ENG'
+```
+
+See [Examples](examples.md) for more, and [Use Cases](use-cases.md) for the scenarios this project is built around.
+
+## Where to go next
+
+| Page | What's in it |
+|---|---|
+| [Background](background.md) | Why this project exists, how it evolved, and the design decisions behind it |
+| [Use Cases](use-cases.md) | The real scenarios this covers, from a single tenant to a multi-customer MSP practice |
+| [Automation & Pipelines](automation.md) | Deep dive into the GitHub Actions multi-customer pipeline, app-only certificate auth, and per-customer GitHub Environments |
+| [Examples](examples.md) | Worked examples for every function, with sample output |
+| [FAQ](faq.md) | Answers to the questions that come up most |
+
+## Project links
+
+- [Source code and issues](https://github.com/sjackson0109/TeamsPublicHolidays)
+- [Changelog](https://github.com/sjackson0109/TeamsPublicHolidays/blob/main/Changelog.md)
+- [License](https://github.com/sjackson0109/TeamsPublicHolidays/blob/main/LICENSE)
+
+These docs are built with GitHub Pages from the `/docs` folder. If you're viewing this on GitHub itself rather than as a published site, the maintainer needs to enable Pages under **Settings > Pages > Source: Deploy from a branch > main / docs**.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,42 @@
+---
+title: Use Cases
+---
+
+[Home](index.md) · [Background](background.md) · [Use Cases](use-cases.md) · [Automation & Pipelines](automation.md) · [Examples](examples.md) · [FAQ](faq.md)
+
+# Use Cases
+
+## 1. Keeping a single tenant's holiday schedule current
+
+The simplest case: one organisation, one Microsoft 365 tenant, one or more auto-attendants that need to route to an out-of-hours greeting on public holidays. Run `New-TeamsPublicHolidays` once to create the schedule, then `Update-TeamsPublicHolidays` each year (or on a schedule) to keep it current. See [Examples](examples.md).
+
+## 2. One schedule, many call flows
+
+A single `CsOnlineSchedule` can be referenced by any number of auto-attendants and call queues. Rather than maintaining holiday dates separately for every call flow, point them all at one schedule (e.g. `UK National Holidays`) and update it in one place - every call flow that references it inherits the change immediately.
+
+## 3. Regional variation within one country
+
+Public holidays frequently differ by region: Bavaria observes holidays the rest of Germany doesn't; Scotland's bank holidays differ from England, Wales, and Northern Ireland's. The `-Region` parameter on `Get-PublicHolidays` / `New-TeamsPublicHolidays` / `Update-TeamsPublicHolidays` filters the holiday set to national (`Global`) holidays plus only the ones relevant to the specified region, so a Bavaria-specific schedule doesn't pick up holidays that only apply to, say, Saxony.
+
+## 4. Annual maintenance without manual intervention
+
+Public holiday schedules need refreshing every year, and it's easy to let this slip. Instead of relying on someone remembering to run the update in December, the [Automation & Pipelines](automation.md) workflow runs on a schedule (1 December) and prepares *next* year's schedule automatically, well ahead of when it's needed - see the [FAQ](faq.md) for exactly which year gets processed and why.
+
+## 5. Correcting or backfilling a specific year
+
+Sometimes you need to process a year other than "next year" - re-running a year where holidays changed after the fact, preparing a schedule further in advance, or fixing a mistake. The pipeline's `workflow_dispatch` trigger accepts an explicit `year` input for exactly this, validated to be a sensible 4-digit year before anything runs.
+
+## 6. Managed Service Providers supporting many customer tenants
+
+This is the use case the [Automation & Pipelines](automation.md) work was built for: an MSP, IT consultancy, or internal platform team responsible for Teams Voice across *many* separate customer Microsoft 365 tenants, each with its own auto-attendants, its own regional holiday requirements, and - critically - its own security boundary.
+
+Rather than an engineer manually running `Connect-MicrosoftTeams` against each customer tenant in turn (the original, fully manual pattern this project started from), the pipeline:
+
+- Reads a simple manifest (`customers.json`) listing every customer and their holiday configuration (country, region, schedule name).
+- Authenticates to each customer's own Entra ID tenant using an app-only certificate registered in that tenant - no interactive sign-in, no shared credential.
+- Keeps every customer's tenant ID, application ID, and certificate isolated in a GitHub Environment named after that customer, so one customer's pipeline run can never see another's secrets.
+- Can be run for every customer on a schedule, or for a single named customer on demand.
+
+## 7. Keeping schedules lean
+
+Old holiday date ranges left in a schedule don't do anything useful and make the schedule slower for Teams to evaluate and harder for a human to read. `Prune-TeamsPublicHolidays` (and the automatic pruning built into `New-`/`Update-TeamsPublicHolidays`) removes date ranges that have already ended, so schedules stay small and relevant.


### PR DESCRIPTION
Adds a Jekyll-based docs site (background, use cases, automation/pipeline deep dive, examples, and a fully populated FAQ) intended to be published via GitHub Pages from the /docs folder. Links to it from the main README.